### PR TITLE
fix: disable removing from data if the evaluated result is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,10 +32,19 @@ module.exports = function (cardscript = {}, data = {}) {
           .join(' && ')
 
         if (isValuePopulated(data[element.id])) {
-          const ast = parse(showWhen).body[0]
+          const ast = parse(showWhen).body[0].expression
           const res = evaluate(ast, { data })
 
-          if (!isValuePopulated(res) || res === false) {
+          // if (res === undefined) {
+          //   console.log('------')
+          //   console.log(`ID: ${element.id}`)
+          //   console.log(`Data: ${data[element.id]}`)
+          //   console.log(`Show when: ${showWhen}`)
+          // }
+
+          // static-eval - If the expression contained in ast can't be statically resolved, evaluate() returns undefined
+          // So cannot use undefined to decide to remove value from data
+          if (res === null || res === false) {
             remove.push(element.id)
           }
         }

--- a/test/fixtures/example-4.json
+++ b/test/fixtures/example-4.json
@@ -1,0 +1,29 @@
+{
+  "templateMeta": {
+    "name": "an-example-form",
+    "title": "An example form",
+    "category": "prevention"
+  },
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "showWhen": "data.colours.find(e => e === 'blue')",
+      "items": [
+        {
+          "id": "number",
+          "title": "Enter a number",
+          "type": "Input.Number"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Submit"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}

--- a/test/transformation-tests.js
+++ b/test/transformation-tests.js
@@ -179,16 +179,6 @@ const tests = [
 ]
 
 describe('Run some Cardscript-post-processor conversions', function () {
-  // it('ignore', () => {
-  //   const parse = require('esprima').parse
-  //   const evaluate = require('static-eval')
-  //   const showWhen = 'data.colours.find(e => e === \'blue\')'
-  //   const data = { colours: ['red', 'blue'] }
-  //   const ast = parse(showWhen).body[0].expression
-  //   const res = evaluate(ast, { data })
-  //   console.log(res)
-  // })
-
   for (const [idx, { cardscript, input, output }] of tests.entries()) {
     it(`Test ${idx + 1}`, function () {
       const [transformedData, removed] = processor(cardscript, input)

--- a/test/transformation-tests.js
+++ b/test/transformation-tests.js
@@ -87,9 +87,9 @@ const tests = [
     },
     output: {
       component1: 'RED',
-      component3: null,
+      component3: 'PINK', // the static-eval result returns undefined :-(
       component4: 'ORANGE',
-      component5: null
+      component5: 'BROWN' // the static-eval result returns undefined :-(
     }
   },
   {
@@ -153,12 +153,44 @@ const tests = [
       ableToTestNow: null,
       numberOfAlarmsFailedTesting: null
     }
+  },
+  {
+    cardscript: require('./fixtures/example-4.json'),
+    input: {
+      colours: ['red', 'blue'],
+      number: 4
+    },
+    output: {
+      colours: ['red', 'blue'],
+      number: 4
+    }
+  },
+  {
+    cardscript: require('./fixtures/example-4.json'),
+    input: {
+      colours: ['red'],
+      number: 3
+    },
+    output: {
+      colours: ['red'],
+      number: 3 // the static-eval result returns undefined :-(
+    }
   }
 ]
 
 describe('Run some Cardscript-post-processor conversions', function () {
+  // it('ignore', () => {
+  //   const parse = require('esprima').parse
+  //   const evaluate = require('static-eval')
+  //   const showWhen = 'data.colours.find(e => e === \'blue\')'
+  //   const data = { colours: ['red', 'blue'] }
+  //   const ast = parse(showWhen).body[0].expression
+  //   const res = evaluate(ast, { data })
+  //   console.log(res)
+  // })
+
   for (const [idx, { cardscript, input, output }] of tests.entries()) {
-    it(`Test ${idx}`, function () {
+    it(`Test ${idx + 1}`, function () {
       const [transformedData, removed] = processor(cardscript, input)
       expect(transformedData).to.eql(output)
       const nullValues = Object.entries(output).filter(([key, value]) => value === null).map(([key]) => key)


### PR DESCRIPTION
static-eval returns undefined on evaluation if an error occurred, but also sometimes we may expect undefined as the result so this is not reliable

> If the expression contained in ast can't be statically resolved, evaluate() returns undefined.
https://www.npmjs.com/package/static-eval#evaluateast-vars